### PR TITLE
Hyperlink DOIs to preferred resolver

### DIFF
--- a/meica.libs/alignp_mepi_anat.py
+++ b/meica.libs/alignp_mepi_anat.py
@@ -2,7 +2,7 @@
 __version__="v3.2 beta1"
 """
 # Multi-Echo ICA, Version %s
-# See http://dx.doi.org/10.1016/j.neuroimage.2011.12.028
+# See https://doi.org/10.1016/j.neuroimage.2011.12.028
 #
 # Kundu, P., Brenowitz, N.D., Voon, V., Worbe, Y., Vertes, P.E., Inati, S.J., Saad, Z.S., 
 # Bandettini, P.A. & Bullmore, E.T. Integrated strategy for improving functional 

--- a/meica.libs/select_model.py
+++ b/meica.libs/select_model.py
@@ -8,7 +8,7 @@ welcome_block="""
 #
 # Kundu, P., Inati, S.J., Evans, J.W., Luh, W.M. & Bandettini, P.A. Differentiating 
 #   BOLD and non-BOLD signals in fMRI time series using multi-echo EPI. NeuroImage (2011).
-# http://dx.doi.org/10.1016/j.neuroimage.2011.12.028
+# https://doi.org/10.1016/j.neuroimage.2011.12.028
 #
 # PROCEDURE 2a: Model fitting and component selection routines
 """

--- a/meica.libs/select_model_fft20d.py
+++ b/meica.libs/select_model_fft20d.py
@@ -8,7 +8,7 @@ welcome_block="""
 #
 # Kundu, P., Inati, S.J., Evans, J.W., Luh, W.M. & Bandettini, P.A. Differentiating 
 #   BOLD and non-BOLD signals in fMRI time series using multi-echo EPI. NeuroImage (2011).
-# http://dx.doi.org/10.1016/j.neuroimage.2011.12.028
+# https://doi.org/10.1016/j.neuroimage.2011.12.028
 #
 # PROCEDURE 2a: Model fitting and component selection routines
 """

--- a/meica.libs/select_model_fft20e.py
+++ b/meica.libs/select_model_fft20e.py
@@ -8,7 +8,7 @@ welcome_block="""
 #
 # Kundu, P., Inati, S.J., Evans, J.W., Luh, W.M. & Bandettini, P.A. Differentiating 
 #   BOLD and non-BOLD signals in fMRI time series using multi-echo EPI. NeuroImage (2011).
-# http://dx.doi.org/10.1016/j.neuroimage.2011.12.028
+# https://doi.org/10.1016/j.neuroimage.2011.12.028
 #
 # PROCEDURE 2a: Model fitting and component selection routines
 """

--- a/meica.libs/t2smap.py
+++ b/meica.libs/t2smap.py
@@ -2,13 +2,13 @@
 __version__="v3.1 beta1"
 welcome_block="""
 # Multi-Echo ICA, Version %s
-# See http://dx.doi.org/10.1016/j.neuroimage.2011.12.028
+# See https://doi.org/10.1016/j.neuroimage.2011.12.028
 # Kundu, P., Inati, S.J., Evans, J.W., Luh, W.M. & Bandettini, P.A. Differentiating 
 #	BOLD and non-BOLD signals in fMRI time series using multi-echo EPI. NeuroImage (2011).
 #
 # Kundu, P., Inati, S.J., Evans, J.W., Luh, W.M. & Bandettini, P.A. Differentiating 
 #   BOLD and non-BOLD signals in fMRI time series using multi-echo EPI. NeuroImage (2011).
-# http://dx.doi.org/10.1016/j.neuroimage.2011.12.028
+# https://doi.org/10.1016/j.neuroimage.2011.12.028
 #
 # t2smap.py version %s 	(c) 2014 Prantik Kundu, Noah Brenowitz, Souheil Inati
 #

--- a/meica.libs/tedana.py
+++ b/meica.libs/tedana.py
@@ -9,7 +9,7 @@ welcome_block="""
 #
 # Kundu, P., Inati, S.J., Evans, J.W., Luh, W.M. & Bandettini, P.A. Differentiating 
 #   BOLD and non-BOLD signals in fMRI time series using multi-echo EPI. NeuroImage (2011).
-# http://dx.doi.org/10.1016/j.neuroimage.2011.12.028
+# https://doi.org/10.1016/j.neuroimage.2011.12.028
 #
 # PROCEDURE 2 : Computes ME-PCA and ME-ICA
 # -Computes T2* map 

--- a/meica.py
+++ b/meica.py
@@ -9,7 +9,7 @@ welcome_block="""
 #
 # Kundu, P., Inati, S.J., Evans, J.W., Luh, W.M. & Bandettini, P.A. Differentiating 
 #   BOLD and non-BOLD signals in fMRI time series using multi-echo EPI. NeuroImage (2011).
-# http://dx.doi.org/10.1016/j.neuroimage.2011.12.028
+# https://doi.org/10.1016/j.neuroimage.2011.12.028
 #
 # meica.py version %s (c) 2014 Prantik Kundu
 # PROCEDURE 1 : Preprocess multi-echo datasets and apply multi-echo ICA based on spatial concatenation


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Thus, I'd hereby like to suggest to update to all static DOI links.

Cheers!